### PR TITLE
Implementation of the solve function for MFP module

### DIFF
--- a/src/lang/while/dataflow/framework/AvailableExpressionMFP.rsc
+++ b/src/lang/while/dataflow/framework/AvailableExpressionMFP.rsc
@@ -1,0 +1,40 @@
+module lang::\while::dataflow::framework::AvailableExpressionMFP
+
+
+import lang::\while::dataflow::framework::MFP;
+import lang::\while::Syntax; 
+import lang::\while::CFG;
+import lang::\while::dataflow::Support;
+
+
+public set[AExp] init(WhileProgram program) {
+	return nonTrivialExpression(program);
+}
+
+public set[AExp] bottom(){
+	return {};
+}
+
+public set[AExp] kill(Block b, WhileProgram program) {
+  	switch(b) {
+    	case stmt(Assignment(str x, _, _)): return ( { } | it + expr | expr <- nonTrivialExpression(program), expHasVariable(x, expr) ); 
+    	default: return {}; 
+  	}
+}
+
+public set[AExp] gen(Block b) {
+  	switch(b) {
+  		case stmt(Assignment(str x, AExp a, _)): return ( {} | it + expr | expr <- nonTrivialExpression(a), !expHasVariable(x, expr) );
+  		case condition(Condition(BExp b, Label _)): return nonTrivialExpression(b);
+  		default: return {};
+  	}
+}
+
+public AbstractMFP[AExp] aeMFP() {
+	return AbstractMFP( Forward(), 
+						set[AExp] (Block b) { return gen(b); },
+						set[AExp] (Block b, WhileProgram program) { return kill(b, program);},
+						set[AExp] (WhileProgram program) { return init(program); },
+						set[AExp] () { return bottom();},
+						Intersection());
+}

--- a/src/lang/while/dataflow/framework/LiveVariableMFP.rsc
+++ b/src/lang/while/dataflow/framework/LiveVariableMFP.rsc
@@ -1,0 +1,50 @@
+module lang::\while::dataflow::framework::LiveVariableMFP
+
+
+import lang::\while::dataflow::framework::MFP;
+import lang::\while::Syntax; 
+import lang::\while::CFG;
+import lang::\while::dataflow::Support;
+import IO;
+
+public set[str] init(WhileProgram program) {
+	return {};
+}
+
+public set[str] bottom(){
+	return {};
+}
+
+public set[str] kill(Block b, WhileProgram program) {
+	switch(b) {
+    	case stmt(Assignment(x, _, _)): return {x};
+    	default: return {};
+  	}
+}
+
+public set[str] gen(Block b) {
+	switch(b) {
+    	case stmt(Assignment(_, a, _)): return FV(a);
+    	case condition(Condition b) : return FV(b);
+    	default: return {};
+  	}
+}
+
+public AbstractMFP[str] lvMFP() {
+	return AbstractMFP( Backward(), 
+						set[str] (Block b) { return gen(b); },
+						set[str] (Block b, WhileProgram program) { return kill(b, program);},
+						set[str] (WhileProgram program) { return init(program); },
+						set[str] () { return bottom();},
+						Union());
+}
+
+public set[str] FV(AExp a){
+	return {x | /Var(x) <- a};
+}
+
+public set[str] FV(Condition b){
+	return {x | /Var(x) <- b};
+}
+
+public set[str] FV(Var(x)) = {x};

--- a/src/lang/while/dataflow/framework/MFP.rsc
+++ b/src/lang/while/dataflow/framework/MFP.rsc
@@ -1,30 +1,73 @@
 module lang::\while::dataflow::framework::MFP
 
-import lang::\while::Syntax; 
+import lang::\while::Syntax;
+import lang::\while::CFG;
+import lang::\while::dataflow::Support;
 
-data ControlFlowGraph = Forward() 
+data Direction = Forward() 
                       | Backward(); 
                       
 data MeetOperator = Union()
                   | Intersection();                       
                       
-alias Mapping[A] = map[Label, set[A]];                       
+alias Mapping[&A] = map[Label, set[&A]];                       
 
-data AbstractMFP[A] = AbstractMFP(ControlFlowGraph cfg, 
-                                  set[A] (Block) gen, 
-                                  set[A] (Block, WhileProgram) kill,
-                                  set[A] (WhileProgram) init, 
-                                  set[A] (WhileProgram) bottom,
+data AbstractMFP[&A] = AbstractMFP(Direction direction, 
+                                  set[&A] (Block) gen, 
+                                  set[&A] (Block, WhileProgram) kill,
+                                  set[&A] (WhileProgram) init, 
+                                  set[&A] () bottom,
                                   MeetOperator operator);
                                   
                                   
-//tuple[Mapping[A] entry, Mapping[A] exit) solve(AbstractMFP[A] a, WhileProgram p) {
-//    
-//}  
-
 CFG constructCFG(Forward(), WhileProgram p) = flow(p);
 CFG constructCFG(Backward(), WhileProgram p) = reverseFlow(p);
 
-set[A] meet(Union(), set[A] l, set[A] r) = l + r;  
-set[A] meet(Intersect(), set[A] l, set[A] r) = l & r;  
+set[&A] meet(Union(), set[&A] l, set[&A] r) = l + r;  
+set[&A] meet(Intersection(), set[&A] l, set[&A] r) = l & r;  
 
+
+
+public tuple[Mapping[&A] entry, Mapping[&A] exit] solveMFP(AbstractMFP[&A] a, WhileProgram program) {
+	Mapping[&A] set2 = ();
+	Mapping[&A] set1 = ();
+
+	for( Label l <- labels(program.s) ) {
+		set2[l] = {};
+		set1[l] = {};
+	}
+	
+	CFG cfg = constructCFG(a.direction, program);
+	
+	Mapping[&A] genSet = ();
+	Mapping[&A] killSet = ();
+	for( Block block <- blocks(program) ) {
+		l1 = label(block); 
+		genSet[l1] = a.gen(block);
+		killSet[l1] = a.kill(block, program);
+	}
+	
+	entryPoints = a.direction == Forward() ? {init(program.s)}: final(program.s);
+	
+	tuple[Mapping[&A], Mapping[&A]] res = <set1, set2>;
+	
+	solve(res) {
+		for( Block block <- blocks(program) ) {
+			l1 = label(block); 
+			
+			if(l1 in entryPoints) {
+			  	set1[l1] = {};
+			} else {
+			  	set1[l1] = (a.init(program) | meet(a.operator, it , set2[l2]) | <l2, l1> <- cfg);
+			}	
+			
+			set2[l1] = (set1[l1] - killSet[l1]) + genSet[l1];
+			res = <set1, set2>;
+		}
+	}
+	if(a.direction == Forward()){	
+		return <set1, set2>;
+	} else {
+		return <set2, set1>;
+	}
+}

--- a/src/lang/while/dataflow/framework/ReachingDefinitionMFP.rsc
+++ b/src/lang/while/dataflow/framework/ReachingDefinitionMFP.rsc
@@ -1,0 +1,41 @@
+module lang::\while::dataflow::framework::ReachingDefinitionMFP
+
+import lang::\while::dataflow::framework::MFP;
+import lang::\while::Syntax; 
+import lang::\while::CFG;
+import lang::\while::dataflow::Support;
+
+alias Abstraction = tuple[str, Label]; 
+
+public set[Abstraction] init(WhileProgram _) {
+	return {};
+}
+
+public set[Abstraction] bottom(){
+	return {};
+}
+
+public set[Abstraction] kill(Block b, WhileProgram _) {
+  	switch(b) {
+  		//TODO solve this bug later:
+  		//Notice that we used "entry" in kill. Should we keep this?
+    	//case stmt(Assignment(x, _, _)): return {<v, l> | <v, l> <- entry, v == x};
+    	default: return {};
+  	}
+}
+
+public set[Abstraction] gen(Block b) {
+	switch(b) {
+    	case stmt(Assignment(x, _, l)): return { <x, l> };
+    	default: return {};
+  	}
+}
+
+public AbstractMFP[Abstraction] rdMFP() {
+	return AbstractMFP( Forward(), 
+						set[Abstraction] (Block b) { return gen(b); },
+						set[Abstraction] (Block b, WhileProgram program) { return kill(b, program);},
+						set[Abstraction] (WhileProgram program) { return init(program); },
+						set[Abstraction] () { return bottom();},
+						Union());
+}

--- a/src/lang/while/dataflow/framework/VeryBusyExpressionMFP.rsc
+++ b/src/lang/while/dataflow/framework/VeryBusyExpressionMFP.rsc
@@ -1,0 +1,42 @@
+module lang::\while::dataflow::framework::VeryBusyExpressionMFP
+
+import lang::\while::dataflow::framework::MFP;
+import lang::\while::Syntax; 
+import lang::\while::CFG;
+import lang::\while::dataflow::Support;
+
+
+public set[AExp] init(WhileProgram program) {
+	return nonTrivialExpression(program);
+}
+
+public set[AExp] bottom(){
+	return {};
+}
+
+public set[AExp] kill(Block b, WhileProgram program) {
+	switch(b) {
+  		case stmt(Assignment(str x, AExp _, _)): return ( {} | it + exp | exp <- nonTrivialExpression(program), expHasVariable(x, exp) );
+  		case stmt(Skip(Label _)): return {};
+  		case condition(Condition(BExp _, Label _)): {};
+	}
+  	return {};
+}
+
+public set[AExp] gen(Block b) {
+  	switch(b) {
+  		case stmt(Assignment(_, AExp a, _)): return nonTrivialExpression(a);
+  		case stmt(Skip(Label _)): return {};
+  		case condition(Condition(BExp b, Label _)): return nonTrivialExpression(b);
+  	}
+  	return {};
+}
+
+public AbstractMFP[AExp] vbMFP() {
+	return AbstractMFP( Backward(), 
+						set[AExp] (Block b) { return gen(b); },
+						set[AExp] (Block b, WhileProgram program) { return kill(b, program);},
+						set[AExp] (WhileProgram program) { return init(program); },
+						set[AExp] () { return bottom();},
+						Intersection());
+}

--- a/test/lang/while/dataflow/framework/AvailableExpressionMFPTest.rsc
+++ b/test/lang/while/dataflow/framework/AvailableExpressionMFPTest.rsc
@@ -1,0 +1,33 @@
+module lang::\while::dataflow::framework::AvailableExpressionMFPTest
+
+import programs::Prog;
+import lang::\while::dataflow::framework::MFP;
+import lang::\while::dataflow::framework::AvailableExpressionMFP;
+import lang::\while::Parser;
+import lang::\while::Syntax; 
+import ParseTree;
+
+
+public AExp parseExp(str x) {
+	return implode(#AExp, parse(#AExpSpec, x));
+}
+
+test bool testAEMFP() {
+	ae = aeMFP();
+	program = progProgram();
+	result = solveMFP(ae, program);
+
+	tuple[Mapping[AExp], Mapping[AExp]] expected = <( 
+		1 : {}
+   		, 2 : {parseExp("a+b")}
+   		, 3 : {parseExp("a+b")}
+   		, 4 : {parseExp("a+b")}
+   		, 5 : {}
+   		), ( 
+   		1 : {parseExp("a+b")}
+   		, 2 : {parseExp("a+b"), parseExp("a*b")}
+   		, 3 : {parseExp("a+b")}
+   		, 4 : {}
+   		, 5 : {parseExp("a+b")} )>;
+	return(result == expected);
+}

--- a/test/lang/while/dataflow/framework/LiveVariableMFPTest.rsc
+++ b/test/lang/while/dataflow/framework/LiveVariableMFPTest.rsc
@@ -1,0 +1,30 @@
+module lang::\while::dataflow::framework::LiveVariableMFPTest
+
+import programs::Factorial;
+import lang::\while::dataflow::framework::MFP;
+import lang::\while::dataflow::framework::LiveVariableMFP;
+import lang::\while::Parser;
+
+
+test bool testLVMFP(){
+	lv = lvMFP();
+	program = factorialProgram();
+	result = solveMFP(lv, program);
+
+	tuple[Mapping[str], Mapping[str]] expected = <(
+		1:{"x"},
+		2:{"y"},
+		3:{"y","z"},
+		4:{"y","z"},
+		5:{"y","z"},
+		6:{}
+	),(
+		1:{"y"},
+		2:{"y","z"},
+		3:{"y","z"},
+		4:{"y","z"},
+		5:{"y","z"},
+		6:{}
+	)>;
+	return(result == expected);
+}

--- a/test/lang/while/dataflow/framework/ReachingDefinitionMFPTest.rsc
+++ b/test/lang/while/dataflow/framework/ReachingDefinitionMFPTest.rsc
@@ -1,0 +1,29 @@
+module lang::\while::dataflow::framework::ReachingDefinitionMFPTest
+
+import programs::Factorial;
+import lang::\while::dataflow::framework::MFP;
+import lang::\while::dataflow::framework::ReachingDefinitionMFP;
+import lang::\while::Parser;
+
+test bool testREMFP(){
+	rd = rdMFP();
+	program = factorialProgram();
+	result = solveMFP(rd, program);
+
+	tuple[Mapping[Abstraction], Mapping[Abstraction]] expected = <( 
+		1 : {}
+   		, 2 : {<"y",1>}
+   		, 3 : {<"y",5>,<"y",1>,<"z",2>,<"z",4>}
+   		, 4 : {<"y",5>,<"y",1>,<"z",2>,<"z",4>}
+   		, 5 : {<"z",4>,<"y",5>,<"y",1>}
+   		, 6 : {<"y",5>,<"y",1>,<"z",2>,<"z",4>} 
+   		), ( 
+   		1 : {<"y",1>}
+   		, 2 : {<"y",1>,<"z",2>}
+   		, 3 : {<"y",5>,<"y",1>,<"z",2>,<"z",4>}
+   		, 4 : {<"z",4>,<"y",5>,<"y",1>}
+   		, 5 : {<"y",5>,<"z",4>}
+   		, 6 : {<"y",6>,<"z",2>,<"z",4>} )>;
+	return(result == expected);
+}
+

--- a/test/lang/while/dataflow/framework/VeryBusyExpressionMFPTest.rsc
+++ b/test/lang/while/dataflow/framework/VeryBusyExpressionMFPTest.rsc
@@ -1,0 +1,34 @@
+module lang::\while::dataflow::framework::VeryBusyExpressionMFPTest
+
+import lang::\while::dataflow::framework::MFP;
+import lang::\while::dataflow::framework::VeryBusyExpressionMFP;
+import programs::VeryBusyProgram;
+import lang::\while::Parser;
+import lang::\while::Syntax; 
+import lang::\while::CFG;
+import ParseTree; 
+
+public AExp parseExp(str x) {
+	return implode(#AExp, parse(#AExpSpec, x));
+}
+
+test bool testVBEMFP(){
+	vb = vbMFP();
+	program = veryBusyProgram();
+	result = solveMFP(vb, program);
+
+	tuple[Mapping[AExp], Mapping[AExp]] expected = <(
+		1:{parseExp("a - b"), parseExp("b - a")},
+		2:{parseExp("a - b"), parseExp("b - a")},
+		3:{parseExp("a - b")},
+		4:{parseExp("a - b"), parseExp("b - a")},
+		5:{parseExp("a - b")}
+	),(
+		1:{parseExp("a - b"), parseExp("b - a")},
+		2:{parseExp("a - b")},
+		3:{},
+		4:{parseExp("a - b")},
+		5:{}
+	)>;
+	return(result == expected);
+}


### PR DESCRIPTION
Guys, I did some work on that “solve” function (main part of the MFP module). Hope this helps somehow. I've also implemented tests based on the already existing Data Flow analysis, id est: Available Expression, Very Busy Expressions, Reaching Definitions and Live Variables.
Unfortunately, ReachingDefinitionsMFP needs some review since inside kill function we need a reference to “entry” (see the picture just below). Do you think that we should pass the “entry” set to the kill function? 
By the way, logic seems very tricky and it would be great if we could review everything else later!

![image](https://user-images.githubusercontent.com/4167122/159187328-1c921fab-c002-4802-9eec-25e517494284.png)
